### PR TITLE
Harden _update_file_content against path traversal (S2083)

### DIFF
--- a/src/python_project_generator/project_generator.py
+++ b/src/python_project_generator/project_generator.py
@@ -1128,12 +1128,12 @@ if __name__ == '__main__':
         for file_pattern in text_files:
             for file_path in project_path.rglob(file_pattern):
                 if file_path.is_file():
-                    self._update_file_content(file_path, replacements)
+                    self._update_file_content(project_path, file_path, replacements)
         
         # Update Python files
         for py_file in project_path.rglob("*.py"):
             if py_file.is_file():
-                self._update_file_content(py_file, replacements)
+                self._update_file_content(project_path, py_file, replacements)
         
         # Rename skeleton directory to new package name
         src_dir = project_path / "src"
@@ -1143,15 +1143,39 @@ if __name__ == '__main__':
                 new_package_dir = src_dir / package_name
                 skeleton_dir.rename(new_package_dir)
     
-    def _update_file_content(self, file_path: Path, replacements: Dict[str, str]):
-        """Update file content with replacements."""
+    def _resolved_path_within_project(self, project_root: Path, candidate: Path) -> Optional[Path]:
+        """Resolve candidate and return it only if it lies under project_root (path injection guard)."""
         try:
-            content = file_path.read_text(encoding='utf-8')
+            root_resolved = project_root.resolve()
+            target_resolved = candidate.resolve()
+        except (OSError, RuntimeError):
+            return None
+        try:
+            target_resolved.relative_to(root_resolved)
+        except ValueError:
+            return None
+        return target_resolved
+    
+    def _update_file_content(self, project_path: Path, file_path: Path, replacements: Dict[str, str]):
+        """Update file content with replacements."""
+        safe_path = self._resolved_path_within_project(project_path, file_path)
+        if safe_path is None:
+            self.logger.warning(f"Skipping update outside project directory: {file_path}")
+            return
+        try:
+            root_resolved = project_path.resolve()
+            rel = safe_path.relative_to(root_resolved)
+            trusted_io_path = root_resolved.joinpath(*rel.parts)
+        except (OSError, RuntimeError, ValueError) as e:
+            self.logger.warning(f"Could not resolve safe path for update {file_path}: {e}")
+            return
+        try:
+            content = trusted_io_path.read_text(encoding='utf-8')
             
             for old_text, new_text in replacements.items():
                 content = content.replace(old_text, new_text)
             
-            file_path.write_text(content, encoding='utf-8')
+            trusted_io_path.write_text(content, encoding='utf-8')
             
         except Exception as e:
             self.logger.warning(f"Could not update {file_path}: {e}")

--- a/src/python_project_generator/project_generator.py
+++ b/src/python_project_generator/project_generator.py
@@ -1143,39 +1143,36 @@ if __name__ == '__main__':
                 new_package_dir = src_dir / package_name
                 skeleton_dir.rename(new_package_dir)
     
-    def _resolved_path_within_project(self, project_root: Path, candidate: Path) -> Optional[Path]:
-        """Resolve candidate and return it only if it lies under project_root (path injection guard)."""
+    def _safe_path_for_project_file_io(self, project_root: Path, candidate: Path) -> Optional[Path]:
+        """Path for file I/O only if candidate resolves under project_root; built stepwise (S2083)."""
         try:
-            root_resolved = project_root.resolve()
-            target_resolved = candidate.resolve()
-        except (OSError, RuntimeError):
+            root = project_root.resolve()
+            resolved = candidate.resolve()
+            rel = resolved.relative_to(root)
+        except (OSError, RuntimeError, ValueError):
             return None
-        try:
-            target_resolved.relative_to(root_resolved)
-        except ValueError:
-            return None
-        return target_resolved
+        path = root
+        for name in rel.parts:
+            if name == "..":
+                return None
+            path = path / name
+        return path
     
     def _update_file_content(self, project_path: Path, file_path: Path, replacements: Dict[str, str]):
         """Update file content with replacements."""
-        safe_path = self._resolved_path_within_project(project_path, file_path)
-        if safe_path is None:
+        path = self._safe_path_for_project_file_io(project_path, file_path)
+        if path is None:
             self.logger.warning(f"Skipping update outside project directory: {file_path}")
             return
         try:
-            root_resolved = project_path.resolve()
-            rel = safe_path.relative_to(root_resolved)
-            trusted_io_path = root_resolved.joinpath(*rel.parts)
-        except (OSError, RuntimeError, ValueError) as e:
-            self.logger.warning(f"Could not resolve safe path for update {file_path}: {e}")
-            return
-        try:
-            content = trusted_io_path.read_text(encoding='utf-8')
+            with path.open("r", encoding="utf-8") as f:
+                content = f.read()
             
             for old_text, new_text in replacements.items():
                 content = content.replace(old_text, new_text)
             
-            trusted_io_path.write_text(content, encoding='utf-8')
+            with path.open("w", encoding="utf-8") as f:
+                f.write(content)
             
         except Exception as e:
             self.logger.warning(f"Could not update {file_path}: {e}")

--- a/tests/test_project_generator.py
+++ b/tests/test_project_generator.py
@@ -173,6 +173,31 @@ class TestProjectGenerator(unittest.TestCase):
         for input_name, expected in test_cases:
             result = self.generator._to_class_name(input_name)
             self.assertEqual(result, expected)
+    
+    def test_update_file_content_skips_path_outside_project(self):
+        """Paths that resolve outside the project root must not be read or written (S2083)."""
+        root = self.temp_dir / "proj"
+        root.mkdir()
+        outside_dir = self.temp_dir / "outside"
+        outside_dir.mkdir()
+        outside_file = outside_dir / "secret.txt"
+        outside_file.write_text("skeleton-unchanged", encoding="utf-8")
+        traversal_path = root / ".." / "outside" / "secret.txt"
+        self.generator._update_file_content(
+            root,
+            traversal_path,
+            {"skeleton-unchanged": "tampered"},
+        )
+        self.assertEqual(outside_file.read_text(encoding="utf-8"), "skeleton-unchanged")
+    
+    def test_update_file_content_updates_file_inside_project(self):
+        """In-project paths still receive placeholder replacement."""
+        root = self.temp_dir / "proj"
+        root.mkdir()
+        target = root / "setup.py"
+        target.write_text("skeleton line", encoding="utf-8")
+        self.generator._update_file_content(root, target, {"skeleton": "my_pkg"})
+        self.assertEqual(target.read_text(encoding="utf-8"), "my_pkg line")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #19 
## Summary of changes
- Validate paths in `_update_file_content` with `resolve()` and containment under the project root (`relative_to`) before read/write.
- Pass `project_path` from `_update_package_references` for both text files and `*.py` updates.
- Added tests: a traversal-style path must not be written; an in-tree file still gets replacements.
## Verification
- `PYTHONPATH=src pytest tests/ -q` — all tests pass.
## Evidence
- Addresses Sonar **pythonsecurity:S2083** by refusing I/O when the resolved path leaves the project directory.
- Regression tests document safe vs unsafe paths.