### PR TITLE
630:P2 Fix bare except in create_icon font load (python:S5754)

### DIFF
--- a/scripts/create_icon.py
+++ b/scripts/create_icon.py
@@ -82,8 +82,8 @@ def create_icon():
         font_size = 80
         font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc",
                                   font_size)
-    except:
-        # Fallback to default font
+    except Exception:
+        # Fallback to default font (do not catch SystemExit / KeyboardInterrupt)
         font = ImageFont.load_default()
 
     title = "PPG"


### PR DESCRIPTION
Closes #20 
## Summary of changes
- Replaced bare `except:` around `ImageFont.truetype` with `except Exception:` so `SystemExit` and `KeyboardInterrupt` are not swallowed (python:S5754).

## Verification
- `PYTHONPATH=src pytest tests/ -q` — all tests pass.
- `pip install pillow` then `python scripts/create_icon.py` — icon generation runs; falls back to default font if the macOS font path is missing.

## Evidence
- Matches python:S5754: no blanket `BaseException` handler for this block.