### PR TITLE
630:P2 Remove duplicate setup_logging definition

### DIFF
--- a/src/python_project_generator/project_generator.py
+++ b/src/python_project_generator/project_generator.py
@@ -6245,15 +6245,6 @@ def setup_logging(level: str = "INFO") -> None:
     )
 
 
-def setup_logging(level: str = "INFO") -> None:
-    """Set up logging configuration."""
-    logging.basicConfig(
-        level=getattr(logging, level.upper()),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler()]
-    )
-
-
 def main():
     """
     Main CLI entry point for the project generator.

--- a/tests/test_project_generator.py
+++ b/tests/test_project_generator.py
@@ -15,7 +15,7 @@ _SRC = _ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from python_project_generator.project_generator import ProjectGenerator, TemplateManager
+from python_project_generator.project_generator import ProjectGenerator, TemplateManager, setup_logging
 
 
 class TestTemplateManager(unittest.TestCase):
@@ -198,6 +198,11 @@ class TestProjectGenerator(unittest.TestCase):
         target.write_text("skeleton line", encoding="utf-8")
         self.generator._update_file_content(root, target, {"skeleton": "my_pkg"})
         self.assertEqual(target.read_text(encoding="utf-8"), "my_pkg line")
+    
+    def test_setup_logging_is_single_definition_and_runs(self):
+        """setup_logging must be callable with no duplicate module-level definitions (#23)."""
+        setup_logging()
+        setup_logging("DEBUG")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #23 

## Summary of changes
- Removed duplicate module-level `setup_logging` in `project_generator.py`.
- Added `test_setup_logging_is_single_definition_and_runs`.

## Verification
- `PYTHONPATH=src pytest tests/ -q` — all pass.

## Evidence
- One canonical definition; callers and `__init__` / GUI imports unchanged.