### PR TITLE
630:P2 Pilot builtin template registry (django-web-app only)

### DIFF
--- a/src/python_project_generator/project_generator.py
+++ b/src/python_project_generator/project_generator.py
@@ -18,6 +18,12 @@ from datetime import datetime
 import json
 
 
+# Pilot (#24): single source of truth for selected builtin templates. Maps template_id -> ProjectGenerator method name.
+_BUILTIN_TEMPLATE_GENERATOR_PILOT: Dict[str, str] = {
+    "django-web-app": "_generate_minimal_template",
+}
+
+
 class TemplateManager:
     """Manages project templates from various sources."""
     
@@ -1239,12 +1245,15 @@ if __name__ == '__main__':
             
             # Generate based on template type
             success = False
-            if template_id == "flask-web-app":
+            if template_id in _BUILTIN_TEMPLATE_GENERATOR_PILOT:
+                gen_name = _BUILTIN_TEMPLATE_GENERATOR_PILOT[template_id]
+                success = getattr(self, gen_name)(
+                    project_path, project_name, package_name, features, metadata
+                )
+            elif template_id == "flask-web-app":
                 success = self._generate_flask_template(project_path, project_name, package_name, features, metadata)
             elif template_id == "fastapi-web-api":
                 success = self._generate_fastapi_template(project_path, project_name, package_name, features, metadata)
-            elif template_id == "django-web-app":
-                success = self._generate_django_template(project_path, project_name, package_name, features, metadata)
             elif template_id == "data-science-project":
                 success = self._generate_data_science_template(project_path, project_name, package_name, features, metadata)
             elif template_id == "machine-learning-project":

--- a/tests/test_project_generator.py
+++ b/tests/test_project_generator.py
@@ -15,7 +15,12 @@ _SRC = _ROOT / "src"
 if str(_SRC) not in sys.path:
     sys.path.insert(0, str(_SRC))
 
-from python_project_generator.project_generator import ProjectGenerator, TemplateManager, setup_logging
+from python_project_generator.project_generator import (
+    ProjectGenerator,
+    TemplateManager,
+    _BUILTIN_TEMPLATE_GENERATOR_PILOT,
+    setup_logging,
+)
 
 
 class TestTemplateManager(unittest.TestCase):
@@ -203,6 +208,36 @@ class TestProjectGenerator(unittest.TestCase):
         """setup_logging must be callable with no duplicate module-level definitions (#23)."""
         setup_logging()
         setup_logging("DEBUG")
+    
+    def test_builtin_template_registry_pilot_django(self):
+        """django-web-app maps via pilot registry to minimal generator (#24)."""
+        self.assertEqual(
+            _BUILTIN_TEMPLATE_GENERATOR_PILOT.get("django-web-app"),
+            "_generate_minimal_template",
+        )
+        project_name = "django_registry_pilot"
+        features = {
+            "cli": False,
+            "tests": True,
+            "pypi_packaging": True,
+            "readme": True,
+            "gitignore": True,
+        }
+        metadata = {
+            "author": "Test",
+            "email": "t@example.com",
+            "description": "test",
+            "version": "0.1.0",
+        }
+        result = self.generator.generate_project(
+            project_name=project_name,
+            output_dir=self.temp_dir,
+            template_id="django-web-app",
+            features=features,
+            metadata=metadata,
+        )
+        self.assertTrue(result)
+        self.assertTrue((self.temp_dir / project_name).is_dir())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #24 

## Summary of changes
- Added `_BUILTIN_TEMPLATE_GENERATOR_PILOT` with a single entry: `django-web-app` → `_generate_minimal_template`.
- `_generate_builtin_project` checks the registry before the existing `elif` ladder; removed the django-only branch from the ladder.
- Left `_generate_django_template` as-is for compatibility. Tests assert mapping + successful generation.

## Verification
- `PYTHONPATH=src pytest tests/ -q` — all pass.

## Evidence
- One template migrated to registry; no wide refactor; behavior for django remains minimal-template output.